### PR TITLE
Fix input resource

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-
+        "php": "^8.0",
     },
     "require-dev": {},
     "autoload": {

--- a/src/ObfuscatorConfig.php
+++ b/src/ObfuscatorConfig.php
@@ -70,11 +70,11 @@ class ObfuscatorConfig
     }
 
     /**
-     * @param $inputResource
+     * @param \GdImage $inputResource
      */
     public function setInputResource( $inputResource )
     {
-        if (get_resource_type($inputResource) !== 'gd') {
+        if (get_class($inputResource) !== \GdImage::class) {
             throw new \Exception(self::WIDTH_ZERO_OR_LESS);
         }
 


### PR DESCRIPTION
- since php 8.0 functions like `imagecreatefromjpeg()` will return a GdImage instance instead of a resource
- therefore the `setInputResource()` method should accept a GdImage instance as well