### PR TITLE
Fix legacy composer notation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "dkerner/voronoi-obfuscate",
     "description": "Create an obfuscated version of a source image",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "type": "library",
     "license": "MIT",
     "authors": [
@@ -19,8 +19,7 @@
             "DKerner\\": "src/"
         },
         "classmap": [
-            { "Nurbs_Point": "src/Nurbs/Point.php" },
-            { "Voronoi": "src/Nurbs/Voronoi.php" }
+            "src/Nurbs/"
         ]
     }
 }


### PR DESCRIPTION
The current entry is not valid Composer syntax. Per Composer's schema, `classmap` is strictly an array of strings — each being a path to a file or directory that Composer scans for class declarations to build the class→file map automatically. Composer never reads explicit `"ClassName": "path"` pairs; it derives them itself from the PHP source.

- Replaced the two object-style pseudo-entries with a single directory entry "src/Nurbs/".
- PSR-4 (DKerner\\ → src/) is untouched and still serves the namespaced classes at the root of src/.